### PR TITLE
fix: Do not show `undefined` endings for non-\n endings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var _ = require('lodash')
 
 module.exports = function (raw) {
   var rawJSON = String(raw)
-  var ending = _.get(rawJSON.match(/}(\n*)$/), 1)
+  var ending = _.get(rawJSON.match(/}(\s*)$/), 1)
   var indent = _.get(rawJSON.match(/^[ \t]+/m), 0)
 
   var data = JSON.parse(rawJSON)

--- a/test.js
+++ b/test.js
@@ -6,7 +6,11 @@ test('json-preserve-indent', function (t) {
     [2, false, ''],
     [4, false, '\n'],
     [1, true, '\n\n'],
-    [2, true, '\n\n\n']
+    [2, true, '\n\n\n'],
+    [2, true, '\r\n'],
+    [2, true, '\r'],
+    [2, true, ' '],
+    [2, true, '\t']
   ].forEach(test.apply.bind(scenario, t))
 
   t.end()


### PR DESCRIPTION
People might use `\r\n` as a newline sequence (e.g. https://github.com/greenkeeperio/greenkeeper/issues/212). Right now this results into an `undefined` added to the formatted JSON.

I propose this fix which will match all whitespace characters after the last closing `}`, because they are all valid. So even if someone ends their `package.json` with a tab or something it will still preserve it.
